### PR TITLE
feat(elastic beanstalk): cart service has been deployed to eb

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Exclude Beanstalk configuration
+.elasticbeanstalk
+
+# Exclude git
+.git
+
+# Exclude IDE settings folders
+.idea
+.vscode
+
+# Exclude node modules and the dist folder since the service will be built inside the container
+dist
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ lerna-debug.log*
 .elasticbeanstalk/*
 !.elasticbeanstalk/*.cfg.yml
 !.elasticbeanstalk/*.global.yml
+
+# Elastic Beanstalk
+.elasticbeanstalk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM node:14.17.6-alpine AS base
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM node:14.17.6-alpine AS application
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY --from=base /app/package*.json ./
+COPY --from=base /app/dist ./dist
+RUN npm ci
+
+USER node
+EXPOSE 4000
+
+CMD ["node", "dist/main.js"]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "eb-init": "eb init -r eu-west-1 serguntchik-cart-api",
+    "eb-create": "eb create -s -c serguntchik-cart-api-dev develop",
+    "eb-deploy": "eb deploy",
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
@@ -14,6 +17,7 @@
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
+    "lint-docker": "docker run --rm -i hadolint/hadolint < Dockerfile",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",


### PR DESCRIPTION
All of the optional tasks have been implemented
To lint a dockerfile, a command `npm run lint-docker` should be executed

FE pull request: https://github.com/serguntchik/shop-frontend/pull/6
FE CloudFront: https://d23x533cdax2wv.cloudfront.net/

The resulting docker image size is 132 MB, which has been said to be enough to get an optional point:

![Screenshot (44)](https://user-images.githubusercontent.com/34121107/133873806-48788de6-dae5-4b7f-9ef1-4d8f233b925d.png)